### PR TITLE
[Testing] Re-Adding Destroy Missions

### DIFF
--- a/scripts/mobile/lair/npc_mission/corellia_drall_patriot_camp.lua
+++ b/scripts/mobile/lair/npc_mission/corellia_drall_patriot_camp.lua
@@ -1,0 +1,12 @@
+corellia_drall_patriot_camp = Lair:new {
+	mobiles = {{"drall_patriot_foot_soldier",1}, {"drall_patriot_legionnaire",1},{"domestic_bageraset",1}},
+	spawnLimit = 8,
+	buildingsVeryEasy = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	buildingsEasy = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	buildingsMedium = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	buildingsHard = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	buildingsVeryHard = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	mobType = "npc"
+}
+
+addLairTemplate("corellia_drall_patriot_camp", corellia_drall_patriot_camp)

--- a/scripts/mobile/lair/npc_mission/corellia_hidden_daggers_camp.lua
+++ b/scripts/mobile/lair/npc_mission/corellia_hidden_daggers_camp.lua
@@ -1,0 +1,12 @@
+corellia_hidden_daggers_camp = Lair:new {
+	mobiles = {{"hidden_daggers_extremist",1}, {"hidden_daggers_dissident",1},{"hidden_daggers_activist",1}},
+	spawnLimit = 8,
+	buildingsVeryEasy = {"object/tangible/lair/base/objective_banner_corellia.iff"},
+	buildingsEasy = {"object/tangible/lair/base/objective_banner_corellia.iff"},
+	buildingsMedium = {"object/tangible/lair/base/objective_banner_corellia.iff"},
+	buildingsHard = {"object/tangible/lair/base/objective_banner_corellia.iff"},
+	buildingsVeryHard = {"object/tangible/lair/base/objective_banner_corellia.iff"},
+	mobType = "npc"
+}
+
+addLairTemplate("corellia_hidden_daggers_camp", corellia_hidden_daggers_camp)

--- a/scripts/mobile/lair/npc_mission/corellia_meatlump_camp.lua
+++ b/scripts/mobile/lair/npc_mission/corellia_meatlump_camp.lua
@@ -1,0 +1,12 @@
+corellia_meatlump_camp = Lair:new {
+	mobiles = {{"meatlump_cretin",1}, {"meatlump_loon",1},{"meatlump_oaf",1}},
+	spawnLimit = 8,
+	buildingsVeryEasy = {"object/tangible/lair/base/objective_banner_generic_2.iff"},
+	buildingsEasy = {"object/tangible/lair/base/objective_banner_generic_2.iff"},
+	buildingsMedium = {"object/tangible/lair/base/objective_banner_generic_2.iff"},
+	buildingsHard = {"object/tangible/lair/base/objective_banner_generic_2.iff"},
+	buildingsVeryHard = {"object/tangible/lair/base/objective_banner_generic_2.iff"},
+	mobType = "npc"
+}
+
+addLairTemplate("corellia_meatlump_camp", corellia_meatlump_camp)

--- a/scripts/mobile/lair/npc_mission/dantooine_janta_scout.lua
+++ b/scripts/mobile/lair/npc_mission/dantooine_janta_scout.lua
@@ -1,0 +1,12 @@
+dantooine_janta_scout = Lair:new {
+	mobiles = {{"janta_scout", 1}},
+	spawnLimit = 8,
+	buildingsVeryEasy = {"object/tangible/lair/base/objective_dantari_monolith.iff"},
+	buildingsEasy = {"object/tangible/lair/base/objective_dantari_monolith.iff",
+	buildingsMedium = {"object/tangible/lair/base/objective_dantari_monolith.iff"},
+	buildingsHard = {"object/tangible/lair/base/objective_dantari_monolith.iff"},
+	buildingsVeryHard = {"object/tangible/lair/base/objective_dantari_monolith.iff"},
+	mobType = "npc"
+}
+
+addLairTemplate("dantooine_janta_scout", dantooine_janta_scout)

--- a/scripts/mobile/lair/npc_mission/dantooine_kunga_scout.lua
+++ b/scripts/mobile/lair/npc_mission/dantooine_kunga_scout.lua
@@ -1,0 +1,12 @@
+dantooine_kunga_scout = Lair:new {
+	mobiles = {{"kunga_scout",1},
+	spawnLimit = 8,
+	buildingsVeryEasy = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	buildingsEasy = {"object/tangible/lair/base/objective_dantari_fire_pit.iff",
+	buildingsMedium = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	buildingsHard = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	buildingsVeryHard = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	mobType = "npc"
+}
+
+addLairTemplate("dantooine_kunga_scout", dantooine_kunga_scout)

--- a/scripts/mobile/lair/npc_mission/dantooine_mokk_scout.lua
+++ b/scripts/mobile/lair/npc_mission/dantooine_mokk_scout.lua
@@ -1,0 +1,12 @@
+dantooine_mokk_scout = Lair:new {
+	mobiles = {{"mokk_scout",1},
+	spawnLimit = 8,
+	buildingsVeryEasy = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	buildingsEasy = {"object/tangible/lair/base/objective_dantari_fire_pit.iff",
+	buildingsMedium = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	buildingsHard = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	buildingsVeryHard = {"object/tangible/lair/base/objective_dantari_fire_pit.iff"},
+	mobType = "npc"
+}
+
+addLairTemplate("dantooine_mokk_scout", dantooine_mokk_scout)

--- a/scripts/mobile/lair/npc_mission/serverobjects.lua
+++ b/scripts/mobile/lair/npc_mission/serverobjects.lua
@@ -67,3 +67,10 @@ includeFile("lair/npc_mission/valarian_camp.lua")
 includeFile("lair/npc_mission/valarian_swooper_camp.lua")
 includeFile("lair/npc_mission/weequay_tribe_camp.lua")
 
+--Tarkin Specific, Re-adding Missing Lairs
+includeFile("lair/npc_mission/corellia_hidden_daggers_camp.lua")
+includeFile("lair/npc_mission/corellia_meatlump_camp.lua")
+includeFile("lair/npc_mission/corellia_drall_patriot_camp.lua")
+includeFile("lair/npc_mission/dantooine_kunga_scout.lua")
+includeFile("lair/npc_mission/dantooine_janta_scout.lua")
+includeFile("lair/npc_mission/dantooine_mokk_scout.lua")

--- a/scripts/mobile/spawn/destroy_mission/corellia_destroy_missions.lua
+++ b/scripts/mobile/spawn/destroy_mission/corellia_destroy_missions.lua
@@ -1,5 +1,5 @@
 corellia_destroy_missions = {
-
+	
 	lairSpawns = {
 		{
 			lairTemplateName = "corellia_gubbur_lair_neutral_small",
@@ -78,7 +78,7 @@ corellia_destroy_missions = {
 			minDifficulty = 9,
 			maxDifficulty = 12,
 			size = 25,
-		},		
+		},	
 		{
 			lairTemplateName = "corellia_gulginaw_nest_neutral_medium",
 			minDifficulty = 11,
@@ -97,6 +97,68 @@ corellia_destroy_missions = {
 			maxDifficulty = 21,
 			size = 25,
 		},
+
+--Tarkin Specific, Re-Adding Missing Lairs
+		{
+			lairTemplateName = "corellia_murra_lair_neutral_medium",
+			minDifficulty = 9,
+			maxDifficulty = 12,
+			size = 25,
+		},
+		{
+			lairTemplateName = "corellia_gurrcat_lair_neutral_medium",
+			minDifficulty = 9,
+			maxDifficulty = 13,
+			size = 25,
+		},
+		{
+			lairTemplateName = "corellia_drall_patriot_camp",
+			minDifficulty = 10,
+			maxDifficulty = 16,
+			size = 25,
+		},	
+		{
+			lairTemplateName = "corellia_dire_cat_pack_neutral_none",
+			minDifficulty = 12,
+			maxDifficulty = 16,
+			size = 25,
+		},
+		{
+			lairTemplateName = "corellia_giant_carrion_spat_flock_neutral_none",
+			minDifficulty = 15,
+			maxDifficulty = 21,
+			size = 25,
+		},
+		{
+			lairTemplateName = "corellia_deranged_wrix_pack_neutral_none",
+			minDifficulty = 16,
+			maxDifficulty = 21,
+			size = 25,
+		},
+		{
+			lairTemplateName = "corellia_humbaba_herd_neutral_none",
+			minDifficulty = 16,
+			maxDifficulty = 21,
+			size = 25,
+		},
+		{
+			lairTemplateName = "corellia_sharnaff_lair_neutral_large",
+			minDifficulty = 28,
+			maxDifficulty = 34,
+			size = 25,
+		},
+		{
+			lairTemplateName = "corellia_hidden_daggers_camp",
+			minDifficulty = 9,
+			maxDifficulty = 15,
+			size = 25,
+		},
+		{
+			lairTemplateName = "corellia_meatlump_camp",
+			minDifficulty = 8,
+			maxDifficulty = 11,
+			size = 25,
+		},	
 	}
 }
 

--- a/scripts/mobile/spawn/destroy_mission/dantooine_destroy_missions.lua
+++ b/scripts/mobile/spawn/destroy_mission/dantooine_destroy_missions.lua
@@ -1,7 +1,7 @@
 dantooine_destroy_missions = {
 
 	lairSpawns = {
-		{
+--[[		{
 			lairTemplateName = "dantooine_bol_lair_neutral_medium_boss_01",
 			minDifficulty = 24,
 			maxDifficulty = 32,
@@ -59,6 +59,26 @@ dantooine_destroy_missions = {
 			lairTemplateName = "dantooine_voritor_tracker_lair_neutral_medium",
 			minDifficulty = 40,
 			maxDifficulty = 50,
+			size = 25,
+		},
+
+--Tarkin Specific, Re-Adding Missing Lairs
+--]]		{
+			lairTemplateName = "dantooine_mokk_scout",
+			minDifficulty = 24,
+			maxDifficulty = 32,
+			size = 25,
+		},
+		{
+			lairTemplateName = "dantooine_kunga_scout",
+			minDifficulty = 24,
+			maxDifficulty = 32,
+			size = 25,
+		},
+		{
+			lairTemplateName = "dantooine_janta_scout",
+			minDifficulty = 24,
+			maxDifficulty = 32,
 			size = 25,
 		},
 	}


### PR DESCRIPTION
On Dantooine, all missions but my added 3 are commented out.  Also lowered the difficulty of those 3 to where I should be able to get (for testing) at TKM.  Corellia is functional.

Steps followed:
1) Create new mission template in npc_mission
2) Declare it in serverobjects.lua
3) Add it to the appropriate planet's destroy mission .lua file in /scripts/mobile/spawn/destroy_mission
